### PR TITLE
Utility function for map/reducing on a Luwak file

### DIFF
--- a/function-contrib-gollum/luwak_mr.md
+++ b/function-contrib-gollum/luwak_mr.md
@@ -1,0 +1,67 @@
+# Map/Reducing Luwak File Data
+
+[Source File on GitHub](https://github.com/basho/riak_function_contrib/blob/master/mapred/erlang/luwak_mr.erl)
+
+## Description and Usage
+
+The primary tool in this module is a function that conforms to the
+interface for "dynamic map/reduce inputs."  This function will allow
+you to set up a map/reduce process for running a computation across
+the blocks of a Luwak file.
+
+To use the function via the Erlang client:
+
+    C:mapred({modfun, luwak_mr, file, <<"my_file_name">>},
+             [... your query ...]).
+
+Over HTTP, structure your JSON query like:
+
+    {"inputs":{"module":"luwak_mr",
+               "function":"file",
+               "arg":"my_file_name"},
+     "query":[... your query ...]}
+
+The luwak_mr:file/3 function will send an input to the map/reduce
+query for each block in the file.  The "KeyData" for the block will be
+its offset in the file.  As a trivial example, you might use this to
+get an ordered list of the first byte of each block like so:
+
+    F = fun(B, O, _) ->
+           <<Y, _/binary>> = luwak_block:data(B),
+           [{Y, O}]
+        end,
+    {ok, Bytes} = C:mapred({modfun,luwak_mr,file,<<"name">>},
+                           [{map, {qfun, F}, none, true}]),
+    OrderedBytes = lists:keysort(2, Bytes),
+    [ Y || {Y, _} <- OrderedBytes.
+
+## Installation
+
+Before using the luwak_mr module, you'll need to build it, and add it
+to the code path on your Riak nodes.
+
+To build luwak_mr with Rebar, add the module to your project, and then
+add then tell rebar to add luwak's include path to the Erlang compiler
+options.  In rebar.config, add:
+
+    {erl_opts, [{i, "/path/to/riak/lib/luwak-1.0.0/include"}]}.
+
+To build luwak_mr with straight erlc commands, add luwak's include
+path with the -I option:
+
+    erl -I/path/to/riak/lib/luwak-1.0.0/include luwak_mr.erl
+
+Once luwak_mr.beam is built, add the directory it's in to Riak's code
+path.  Edit Riak's app.config, find the riak_kv section, and add and
+add_paths parameter.  For example, if you compiled luwak_mr.beam to
+/foo/luwak_mr/ebin/luwak_mr.beam, then your app.config should read:
+
+    {riak_kv,
+     ... other options ...
+     {add_paths, ["/foo/luwak_mr/ebin"]}
+    }
+
+Or, if your Riak nodes are already running, connect to each node's
+console, and execute the following:
+
+    (riak@127.0.0.1)> code:add_path("/foo/luwak_mr/ebin").

--- a/function-contrib-gollum/map-reduce-functions.textile
+++ b/function-contrib-gollum/map-reduce-functions.textile
@@ -17,6 +17,7 @@ h2. Contributed Functions
 [[Save the Result of a Map to a Riak Bucket/Key (Erlang)|save_reduce]]
 [[Sorting by Field (JS)|sorting-by-field]]
 [[Stats (JS)|stats]]
+[[Luwak Files (Erlang)|luwak_mr]]
 
 
 

--- a/mapreduce/erlang/luwak_mr.erl
+++ b/mapreduce/erlang/luwak_mr.erl
@@ -1,0 +1,105 @@
+%% -------------------------------------------------------------------
+%% luwak_mr: utilities for map/reducing on Luwak data
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%  http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Tools for map/reducing Luwak data.
+%%
+%%      The primary tool in this module is a function that conforms to
+%%      the interface for "dynamic map/reduce inputs."  This function
+%%      will allow you to set up a map/reduce process for running a
+%%      computation across the blocks of a Luwak file.
+%%
+%%      To use the function via the Erlang client:
+%%```
+%%      C:mapred({modfun, luwak_mr, file, <<"my_file_name">>},
+%%               [... your query ...]).
+%%'''
+%%      Over HTTP, structure your JSON query like:
+%%```
+%%      {"inputs":{"module":"luwak_mr",
+%%                 "function":"file",
+%%                 "arg":"my_file_name"},
+%%       "query":[... your query ...]}
+%%'''
+%%
+%%      The luwak_mr:file/3 function will send an input to the
+%%      map/reduce query for each block in the file.  The "KeyData"
+%%      for the block will be its offset in the file.  As a trivial
+%%      example, you might use this to get an ordered list of the
+%%      first byte of each block like so:
+%%```
+%%      F = fun(B, O, _) ->
+%%             <<Y, _/binary>> = luwak_block:data(B),
+%%             [{Y, O}]
+%%          end,
+%%      {ok, Bytes} = C:mapred({modfun,luwak_mr,file,<<"name">>},
+%%                             [{map, {qfun, F}, none, true}]),
+%%      OrderedBytes = lists:keysort(2, Bytes),
+%%      [ Y || {Y, _} <- OrderedBytes.
+%%'''
+
+-module(luwak_mr).
+
+-export([file/3]).
+
+-include("luwak.hrl").
+
+%% @spec file(pid(), binary(), integer()) -> ok
+%% @doc Sends the bucket-keys for the blocks of a Luwak file as
+%%      map/reduce inputs to the specified FlowPid.  Use it by
+%%      specifying the map/reduce input as:
+%%```
+%%      {modfun, luwak_mr, file, <<"file_name">>}
+%%'''
+file(FlowPid, Filename, _Timeout) when is_binary(Filename) ->
+    {ok, Client} = riak:local_client(),
+
+    {ok, File} = luwak_file:get(Client, Filename),
+    V = riak_object:get_value(File),
+    {block_size, BlockSize} = lists:keyfind(block_size, 1, V),
+
+    case lists:keyfind(root, 1, V) of
+        {root, RootKey} -> tree(FlowPid, Client, BlockSize, RootKey, 0);
+        false           -> ok
+    end,
+
+    luke_flow:finish_inputs(FlowPid).
+
+%% @spec tree(pid(), riak_client(), integer(), binary(), integer())
+%%          -> integer()
+%% @doc Recursive tree walker used by file/3.  This function assumes
+%%      that a child link in a tree is a data block if the size it
+%%      lists is less than or equal to the specified BlockSize, and
+%%      that it is a subtree if the size is greater than BlockSize.
+%%
+%%      The result is the offset of the byte that would imediately
+%%      follow all of the bytes in this tree.  This fact is unused,
+%%      but *could* be used for testing an invariant.
+tree(FlowPid, Client, BlockSize, Key, Offset) ->
+    {ok, #n{children=Children}} = luwak_tree:get(Client, Key),
+    lists:foldl(
+      fun({SubTree, Size}, SubOffset) when Size > BlockSize ->
+              tree(FlowPid, Client, BlockSize, SubTree, SubOffset),
+              SubOffset+Size;
+         ({Leaf, Size}, LeafOffset) ->
+              luke_flow:add_inputs(
+                FlowPid, [{{?N_BUCKET, Leaf}, LeafOffset}]),
+              LeafOffset+Size
+      end,
+      Offset,
+      Children).


### PR DESCRIPTION
The luwak_mr module exports the file/3 function for enabling a map/reduce query to process a Luwak file.  To use it, simply:

```
C:mapred({modfun, luwak_mr, file, <<"my_file_name">>},
         [... your query ...]).
```

If the query given starts with a map phase, the function in that phase will be evaluated against each block of the named luwak file.  The KeyData argument to the function will be that block's offset in the file.

An example usage is available at https://github.com/beerriot/luwak_mr/blob/master/src/luwak_mr_words.erl
