### PR TITLE
Erlang delete_keys reduce job improvements

### DIFF
--- a/mapreduce/erlang/delete_keys.erl
+++ b/mapreduce/erlang/delete_keys.erl
@@ -22,16 +22,29 @@
 
 -export([delete/2]).
 
-%Data is a list of bucket and key pairs
-delete(Data, _None) ->
-    {ok, C} = riak:local_client(),
-    F = fun(BucketKey, Acc) ->
-                case BucketKey of
-                    [Bucket, Key] ->
-                        C:delete(Bucket, Key, 0),
-                        Acc + 1;
-                    _ ->
-                        Acc
-                end end,
-    lists:foldl(F, 0, Data),
-    [length(Data)].
+% Data is a list of bucket and key pairs, intermixed with the counts of deleted
+% objects. Returns a count of deleted objects.
+delete(List, _None) ->
+  {ok, C} = riak:local_client(),
+
+  Delete = fun(Bucket, Key) ->
+    case C:delete(Bucket, Key, 0) of
+      ok -> 1;
+      _ -> 0
+    end
+  end,
+
+  F = fun(Elem, Acc) ->
+    case Elem of
+      {{Bucket, Key}, _KeyData} ->
+        Acc + Delete(Bucket, Key);
+      {Bucket, Key} ->
+        Acc + Delete(Bucket, Key);
+      [Bucket, Key] ->
+        Acc + Delete(Bucket, Key);
+      _ ->
+        Acc + Elem
+    end
+  end,
+  
+  [lists:foldl(F, 0, List)]


### PR DESCRIPTION
Can be re-reduced
Counts deletes instead of inputs
Works on standard inputs to reduce phases
