### PR TITLE
Erlang pre-commit example

### DIFF
--- a/function-contrib-gollum/uppercase_text_erl.textile
+++ b/function-contrib-gollum/uppercase_text_erl.textile
@@ -1,0 +1,19 @@
+h1. Uppercase Text Pre-Commit Hook (Erlang)
+
+[[Source File on GitHub|https://github.com/basho/riak_function_contrib/blob/master/hooks/pre-commit/erlang/uppercase_text.erl]] 
+
+This function can be used in a pre-commit hook to force all letters to UPPERCASE in a text document.
+
+```erlang
+-module(uppercase_text).
+
+-export([uppertext/1]).
+
+uppertext(IncomingObject) ->
+  BinaryContent = riak_object:get_value(IncomingObject),
+  StringContent = binary:bin_to_list(BinaryContent),
+  UpperStringContent = string:to_upper(StringContent),
+  UpperBinaryContent = binary:list_to_bin(UpperStringContent),
+  riak_object:apply_updates(riak_object:update_value(IncomingObject, UpperBinaryContent)).
+```
+

--- a/hooks/pre-commit/erlang/uppercase_text.erl
+++ b/hooks/pre-commit/erlang/uppercase_text.erl
@@ -1,0 +1,29 @@
+
+%% Author: Hal Eisen (hal.eisen@ask.com)
+
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%  http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+
+-module(uppercase_text).
+
+-export([uppertext/1]).
+
+uppertext(IncomingObject) ->
+  BinaryContent = riak_object:get_value(IncomingObject),
+  StringContent = binary:bin_to_list(BinaryContent),
+  UpperStringContent = string:to_upper(StringContent),
+  UpperBinaryContent = binary:list_to_bin(UpperStringContent),
+  riak_object:apply_updates(riak_object:update_value(IncomingObject, UpperBinaryContent)).
+


### PR DESCRIPTION
This is some sample code showing how a pre-commit hook can be used to modify a key's value before that value is stored on disk.  To keep it simple, I did this for plain text files.  Next, I'll do one which modifies some JSON on the fly.

Hal