### PR TITLE
Fixing the Erlang get_keys and delete_keys samples

### DIFF
--- a/function-contrib-gollum/delete_keys.textile
+++ b/function-contrib-gollum/delete_keys.textile
@@ -34,7 +34,7 @@ delete(List, _None) ->
     end
   end,
   
-  [lists:foldl(F, 0, List)]
+  [lists:foldl(F, 0, List)].
 ```
 
 

--- a/function-contrib-gollum/get_keys.textile
+++ b/function-contrib-gollum/get_keys.textile
@@ -15,7 +15,7 @@ The Erlang module:
 
 %Returns bucket and key pairs from a map phase
 get_keys(Value,_Keydata,_Arg) ->
-  [{riak_object:bucket(Value),riak_object:key(Value)}].
+  [[riak_object:bucket(Value),riak_object:key(Value)]].
 ```
 
 The Javascript function:
@@ -25,5 +25,3 @@ function get_keys(object, keyData, arg){
   return [[object.bucket, object.key]]
 }
 ```
-
-

--- a/mapreduce/erlang/delete_keys.erl
+++ b/mapreduce/erlang/delete_keys.erl
@@ -47,4 +47,4 @@ delete(List, _None) ->
     end
   end,
   
-  [lists:foldl(F, 0, List)]
+  [lists:foldl(F, 0, List)].

--- a/mapreduce/erlang/get_keys.erl
+++ b/mapreduce/erlang/get_keys.erl
@@ -24,4 +24,4 @@
 
 %Returns bucket and key pairs from a map phase
 get_keys(Value,_Keydata,_Arg) ->
-  [{riak_object:bucket(Value),riak_object:key(Value)}].
+  [[riak_object:bucket(Value),riak_object:key(Value)]].


### PR DESCRIPTION
Updating the `get_keys` sample to return data in the same format as the equivalent Javascript function. I also found out that the output returned previously wasn't compatible with the input required by `delete_keys`.

Fixing a **syntax error** in `delete_keys` which caused a compilation error.